### PR TITLE
Fix PostService to use ConcurrentQueue API

### DIFF
--- a/OrleansBlog/Services/PostService.cs
+++ b/OrleansBlog/Services/PostService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using OrleansBlog.Abstractions;
 using OrleansBlog.Models;
 
@@ -34,7 +35,7 @@ namespace OrleansBlog.Services
             orleansPost.Id = (int)postId;
             
             await grain.CreatePost(orleansPost);
-            _postIds.Add(postId);
+            _postIds.Enqueue(postId);
             
             return postId;
         }


### PR DESCRIPTION
## Summary
- Fixed PostService to properly use ConcurrentQueue.Enqueue() instead of Add()
- Added missing System.Collections.Concurrent using statement

## Test plan
- [ ] Verify PostService compiles without errors
- [ ] Confirm post creation functionality works correctly
- [ ] Run existing tests to ensure no regression

🤖 Generated with [Claude Code](https://claude.ai/code)